### PR TITLE
Fix MSVC build error C2397 (narrowing conversion)

### DIFF
--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <functional>
 #include <random>
+#include <limits>
 #include <type_traits>
 
 namespace signalsmith { namespace stretch {
@@ -404,7 +405,7 @@ struct SignalsmithStretch {
 private:
 	bool _splitComputation = false;
 	struct {
-		size_t samplesSinceLast = -1;
+		size_t samplesSinceLast = std::numeric_limits<size_t>::max();
 		size_t steps = 0;
 		size_t step = 0;
 		


### PR DESCRIPTION
signalsmith-stretch.h(407,29): error C2397: conversion from 'int' to 'size_t' requires a narrowing conversion

MSBuild version 17.13.15+18b3035f6 for .NET Framework