### PR TITLE
[WIP] Improve `.outputSeek()` performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
 	signalsmith-linear
 	GIT_REPOSITORY https://github.com/Signalsmith-Audio/linear.git
-	GIT_TAG 0.2.4
+	GIT_TAG 0.2.8
 	GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(signalsmith-linear)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
 	signalsmith-linear
 	GIT_REPOSITORY https://github.com/Signalsmith-Audio/linear.git
-	GIT_TAG 0.2.8
+	GIT_TAG 0.3.0
 	GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(signalsmith-linear)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
 	signalsmith-linear
 	GIT_REPOSITORY https://github.com/Signalsmith-Audio/linear.git
-	GIT_TAG 0.2.3
+	GIT_TAG 0.2.4
 	GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(signalsmith-linear)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,5 +1,13 @@
 all: out/stretch
 
+dev: out/stretch
+	./out/stretch inputs/dev.wav out/dev-2048.wav --process-chunk=2048 --semitones=4
+	./out/stretch inputs/dev.wav out/dev-512.wav --process-chunk=512 --semitones=4
+	./out/stretch inputs/dev.wav out/dev-100.wav --process-chunk=100 --semitones=4
+	./out/stretch inputs/dev.wav out/dev-2048-sc.wav --process-chunk=2048 --split-computation --semitones=4
+	./out/stretch inputs/dev.wav out/dev-512-sc.wav --process-chunk=512 --split-computation --semitones=4
+	./out/stretch inputs/dev.wav out/dev-100-sc.wav --process-chunk=100 --split-computation --semitones=4
+
 out/stretch: main.cpp ../signalsmith-stretch.h util/*.h util/*.hxx
 	mkdir -p out
 	g++ -std=c++11 -O3 -g \
@@ -26,13 +34,6 @@ examples: out/stretch
 	inputs/run-all.sh out/examples/t4- out/stretch --time=4 --asymmetry=0.5
 
 TEST_WAV ?= "inputs/voice.wav"
-
-dev: out/stretch
-	out/stretch --time=0.8 --semitones=10 $(TEST_WAV) out/shift.wav
-	out/stretch --time=0.8 --semitones=10 --formant-comp $(TEST_WAV) out/shift-fc.wav
-	out/stretch --time=0.8 --semitones=10 --formant-comp --formant=3 $(TEST_WAV) out/shift-fc-f3.wav
-	out/stretch --time=0.8 --semitones=10 --formant-comp --formant=3 --formant-base=500 $(TEST_WAV) out/shift-fc-f3-fb500.wav
-	out/stretch --time=0.8 --semitones=10 --formant-comp --formant=2 --formant-base=100 $(TEST_WAV) out/shift-fc-f2-fb100.wav
 
 clean:
 	rm -rf out

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -11,19 +11,19 @@ out/stretch: main.cpp ../signalsmith-stretch.h util/*.h util/*.hxx
 # Uses input files from: https://signalsmith-audio.co.uk/code/stretch/inputs.zip
 examples: out/stretch
 	mkdir -p out/examples
-	inputs/run-all.sh out/examples/u2- out/stretch --semitones=2
-	inputs/run-all.sh out/examples/d2- out/stretch --semitones=-2
-	inputs/run-all.sh out/examples/u4- out/stretch --semitones=4
-	inputs/run-all.sh out/examples/d4- out/stretch --semitones=-4
-	inputs/run-all.sh out/examples/u8- out/stretch --semitones=8
-	inputs/run-all.sh out/examples/d8- out/stretch --semitones=-8
-	inputs/run-all.sh out/examples/u16- out/stretch --semitones=16
-	inputs/run-all.sh out/examples/d16- out/stretch --semitones=-16
-	inputs/run-all.sh out/examples/t_8- out/stretch --time=0.8
-	inputs/run-all.sh out/examples/t1_2- out/stretch --time=1.2
-	inputs/run-all.sh out/examples/t1_5- out/stretch --time=1.5
-	inputs/run-all.sh out/examples/t2- out/stretch --time=2
-	inputs/run-all.sh out/examples/t4- out/stretch --time=4
+	inputs/run-all.sh out/examples/u2- out/stretch --semitones=2 --asymmetry=0.5
+	inputs/run-all.sh out/examples/d2- out/stretch --semitones=-2 --asymmetry=0.5
+	inputs/run-all.sh out/examples/u4- out/stretch --semitones=4 --asymmetry=0.5
+	inputs/run-all.sh out/examples/d4- out/stretch --semitones=-4 --asymmetry=0.5
+	inputs/run-all.sh out/examples/u8- out/stretch --semitones=8 --asymmetry=0.5
+	inputs/run-all.sh out/examples/d8- out/stretch --semitones=-8 --asymmetry=0.5
+	inputs/run-all.sh out/examples/u16- out/stretch --semitones=16 --asymmetry=0.5
+	inputs/run-all.sh out/examples/d16- out/stretch --semitones=-16 --asymmetry=0.5
+	inputs/run-all.sh out/examples/t_8- out/stretch --time=0.8 --asymmetry=0.5
+	inputs/run-all.sh out/examples/t1_2- out/stretch --time=1.2 --asymmetry=0.5
+	inputs/run-all.sh out/examples/t1_5- out/stretch --time=1.5 --asymmetry=0.5
+	inputs/run-all.sh out/examples/t2- out/stretch --time=2 --asymmetry=0.5
+	inputs/run-all.sh out/examples/t4- out/stretch --time=4 --asymmetry=0.5
 
 TEST_WAV ?= "inputs/voice.wav"
 

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,6 +1,6 @@
 all: out/stretch
 
-DEV_FLAGS := --semitones=4 --time=0.667
+DEV_FLAGS := --semitones=4 --time=0.667 --asymmetry=0.5
 
 dev: out/stretch
 	./out/stretch inputs/dev.wav out/dev-2048.wav --process-chunk=2048 $(DEV_FLAGS)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,6 +1,6 @@
 all: out/stretch
 
-DEV_FLAGS := --semitones=4 --time=1
+DEV_FLAGS := --semitones=4 --time=0.667
 
 dev: out/stretch
 	./out/stretch inputs/dev.wav out/dev-2048.wav --process-chunk=2048 $(DEV_FLAGS)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,12 +1,14 @@
 all: out/stretch
 
+DEV_FLAGS := --semitones=4 --time=1
+
 dev: out/stretch
-	./out/stretch inputs/dev.wav out/dev-2048.wav --process-chunk=2048 --semitones=4
-	./out/stretch inputs/dev.wav out/dev-512.wav --process-chunk=512 --semitones=4
-	./out/stretch inputs/dev.wav out/dev-100.wav --process-chunk=100 --semitones=4
-	./out/stretch inputs/dev.wav out/dev-2048-sc.wav --process-chunk=2048 --split-computation --semitones=4
-	./out/stretch inputs/dev.wav out/dev-512-sc.wav --process-chunk=512 --split-computation --semitones=4
-	./out/stretch inputs/dev.wav out/dev-100-sc.wav --process-chunk=100 --split-computation --semitones=4
+	./out/stretch inputs/dev.wav out/dev-2048.wav --process-chunk=2048 $(DEV_FLAGS)
+	./out/stretch inputs/dev.wav out/dev-512.wav --process-chunk=512 $(DEV_FLAGS)
+	./out/stretch inputs/dev.wav out/dev-100.wav --process-chunk=100 $(DEV_FLAGS)
+	./out/stretch inputs/dev.wav out/dev-2048-sc.wav --process-chunk=2048 --split-computation $(DEV_FLAGS)
+	./out/stretch inputs/dev.wav out/dev-512-sc.wav --process-chunk=512 --split-computation $(DEV_FLAGS)
+	./out/stretch inputs/dev.wav out/dev-100-sc.wav --process-chunk=100 --split-computation $(DEV_FLAGS)
 
 out/stretch: main.cpp ../signalsmith-stretch.h util/*.h util/*.hxx
 	mkdir -p out
@@ -19,19 +21,19 @@ out/stretch: main.cpp ../signalsmith-stretch.h util/*.h util/*.hxx
 # Uses input files from: https://signalsmith-audio.co.uk/code/stretch/inputs.zip
 examples: out/stretch
 	mkdir -p out/examples
-	inputs/run-all.sh out/examples/u2- out/stretch --semitones=2 --asymmetry=0.5
-	inputs/run-all.sh out/examples/d2- out/stretch --semitones=-2 --asymmetry=0.5
-	inputs/run-all.sh out/examples/u4- out/stretch --semitones=4 --asymmetry=0.5
-	inputs/run-all.sh out/examples/d4- out/stretch --semitones=-4 --asymmetry=0.5
-	inputs/run-all.sh out/examples/u8- out/stretch --semitones=8 --asymmetry=0.5
-	inputs/run-all.sh out/examples/d8- out/stretch --semitones=-8 --asymmetry=0.5
-	inputs/run-all.sh out/examples/u16- out/stretch --semitones=16 --asymmetry=0.5
-	inputs/run-all.sh out/examples/d16- out/stretch --semitones=-16 --asymmetry=0.5
-	inputs/run-all.sh out/examples/t_8- out/stretch --time=0.8 --asymmetry=0.5
-	inputs/run-all.sh out/examples/t1_2- out/stretch --time=1.2 --asymmetry=0.5
-	inputs/run-all.sh out/examples/t1_5- out/stretch --time=1.5 --asymmetry=0.5
-	inputs/run-all.sh out/examples/t2- out/stretch --time=2 --asymmetry=0.5
-	inputs/run-all.sh out/examples/t4- out/stretch --time=4 --asymmetry=0.5
+	inputs/run-all.sh out/examples/u2- out/stretch --semitones=2
+	inputs/run-all.sh out/examples/d2- out/stretch --semitones=-2
+	inputs/run-all.sh out/examples/u4- out/stretch --semitones=4
+	inputs/run-all.sh out/examples/d4- out/stretch --semitones=-4
+	inputs/run-all.sh out/examples/u8- out/stretch --semitones=8
+	inputs/run-all.sh out/examples/d8- out/stretch --semitones=-8
+	inputs/run-all.sh out/examples/u16- out/stretch --semitones=16
+	inputs/run-all.sh out/examples/d16- out/stretch --semitones=-16
+	inputs/run-all.sh out/examples/t_8- out/stretch --time=0.8
+	inputs/run-all.sh out/examples/t1_2- out/stretch --time=1.2
+	inputs/run-all.sh out/examples/t1_5- out/stretch --time=1.5
+	inputs/run-all.sh out/examples/t2- out/stretch --time=2
+	inputs/run-all.sh out/examples/t4- out/stretch --time=4
 
 TEST_WAV ?= "inputs/voice.wav"
 

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -67,23 +67,17 @@ int main(int argc, char* argv[]) {
 	// At this point, the next output samples we get will correspond to the beginning of the audio file.
 
 	// We're going to process until *just* before the end of the audio file (so we can get a tidier end using `.flush()`.
-	int outputIndex = outputLength - stretch.intervalSamples();
+	int outputMainBlockLength = outputLength - stretch.intervalSamples();
+	// And this is how much input we'll need for that
+	int inputMainBlockLength = outputMainBlockLength/time;
 
-	// Stretch's internal output position is slightly ahead of the output samples we get
-	int outputPos = outputIndex + stretch.outputLatency();
-	// Time-map: where do we want the input position to be at that moment?
-	int inputPos = std::round(outputPos/time);
-	// And therefore which input samples do we need to be supplying?
-	int inputIndex = inputPos + stretch.inputLatency();
-	
-	// In this particular case, our `inputPos` will be at the end of the file
-	// and `inputIndex` will be beyond the end, so we pad with 0s to have enough input
-	inWav.resize(inputIndex);
+	// This zero-pads the input, since we'll go past the end of it
+	inWav.resize(inputMainBlockLength + seekLength);
 
-	// OK, go for it
+	// Main block of processing
 	inWav.offset = seekLength;
 	if (processChunkSize <= 0) {
-		stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
+		stretch.process(inWav, inputMainBlockLength, outWav, outputMainBlockLength);
 	} else {
 		// Plot computation time for each chunk
 		signalsmith::plot::Plot2D timePlot(500, 200);
@@ -100,19 +94,19 @@ int main(int argc, char* argv[]) {
 		timeLineSeek.add(inWav.offset, 0);
 	
 		float residue = 0.f;
-		while (inWav.offset < size_t(inputIndex)) {
-			int toProcess = std::min<int>(processChunkSize, inputIndex - inWav.offset);
-			float outputPrecise = toProcess * time + residue;
-			int outputSamples = std::round(outputPrecise);
-			residue = outputPrecise - outputSamples;
+		while (outWav.offset < size_t(outputMainBlockLength)) {
+			int outputSamples = std::min<int>(processChunkSize, outputMainBlockLength - outWav.offset);
+			float inputPrecise = outputSamples/time + residue;
+			int inputSamples = std::round(inputPrecise);
+			residue = inputPrecise - inputSamples;
 
 			stopwatch.startLap();
-			stretch.process(inWav, toProcess, outWav, outputSamples);
+			stretch.process(inWav, inputSamples, outWav, outputSamples);
 			double time = stopwatch.seconds(stopwatch.lap());
 			timeLine.add(outWav.offset, time);
 			timeLine.add(outWav.offset + outputSamples, time);
 			
-			inWav.offset += toProcess;
+			inWav.offset += inputSamples;
 			outWav.offset += outputSamples;
 		}
 		
@@ -121,8 +115,8 @@ int main(int argc, char* argv[]) {
 	}
 	
 	// And as promised, get the last bits using `.flush()`, which does some extra stuff to avoid introducing clicks.
-	outWav.offset = outputIndex;
-	stretch.flush(outWav, outputLength - outputIndex);
+	outWav.offset = outputMainBlockLength;
+	stretch.flush(outWav, outputLength - outputMainBlockLength);
 	outWav.offset = 0;
 
 	if (!outWav.write(outputWav).warn()) args.errorExit("failed to write WAV");

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -19,12 +19,13 @@ int main(int argc, char* argv[]) {
 
 	std::string inputWav = args.arg<std::string>("input.wav", "16-bit WAV file");
 	std::string outputWav = args.arg<std::string>("output.wav", "output WAV file");
+	double time = args.flag<double>("time", "time-stretch factor", 1);
 	double semitones = args.flag<double>("semitones", "pitch-shift amount", 0);
 	double formants = args.flag<double>("formant", "formant-shift amount (semitones)", 0);
 	bool formantComp = args.hasFlag("formant-comp", "formant compensation");
 	double formantBase = args.flag<double>("formant-base", "formant base frequency (Hz, 0=auto)", 100);
 	double tonality = args.flag<double>("tonality", "tonality limit (Hz)", 8000);
-	double time = args.flag<double>("time", "time-stretch factor", 1);
+	double asymmetry = args.flag<double>("asymmetry", "asymmetrical STFT analysis (0-1)", 0);
 	bool splitComputation = args.hasFlag("split-computation", "distributes the computation more evenly (but higher latency)");
 	args.errorExit(); // exits on error, or with `--help`
 
@@ -42,7 +43,7 @@ int main(int argc, char* argv[]) {
 	outWav.resize(outputLength);
 
 	SignalsmithStretch stretch;
-	stretch.presetDefault(int(inWav.channels), inWav.sampleRate, splitComputation);
+	stretch.configure(int(inWav.channels), inWav.sampleRate*0.12, inWav.sampleRate*0.03, splitComputation, asymmetry);
 	stretch.setTransposeSemitones(semitones, tonality/inWav.sampleRate);
 	stretch.setFormantSemitones(formants, formantComp);
 	stretch.setFormantBase(formantBase/inWav.sampleRate);

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -52,6 +52,37 @@ int main(int argc, char* argv[]) {
 	stretch.setFormantSemitones(formants, formantComp);
 	stretch.setFormantBase(formantBase/inWav.sampleRate);
 
+	signalsmith::plot::Figure figure;
+	auto writeLater = figure.writeLater(outputWav + "-blocks.svg");
+	size_t plotBlockCounter = 0;
+	{
+		auto &inputPlot = figure(0, 0).plot(800, 150);
+		inputPlot.x.major(0);
+		inputPlot.y.major(0);
+		auto &outputPlot = figure(0, 1).plot(800, 150);
+		outputPlot.x.major(0);
+		outputPlot.y.major(0);
+
+		stretch.debugAnalysis = [&](int inputOffset, const float *window, bool isPrevious){
+			if (plotBlockCounter > 10) return;
+			int blockSamples = stretch.blockSamples();
+			auto &line = inputPlot.line(plotBlockCounter);
+			for (int i = 0; i < blockSamples; ++i) {
+				line.add(inputOffset - blockSamples + i + int(inWav.offset), window[i]);
+			}
+		};
+		stretch.debugSynthesis = [&](int outputOffset, const float *window){
+			if (plotBlockCounter > 10) return;
+			int blockSamples = stretch.blockSamples();
+			auto &line = outputPlot.line(plotBlockCounter);
+			for (int i = 0; i < blockSamples; ++i) {
+				line.add(outputOffset + i + int(outWav.offset), window[i]);
+			}
+
+			++plotBlockCounter;
+		};
+	}
+
 	/* Since the WAV helper allows sample access like `wav[c][index]`, we could just call:
 	
 		stretch.exact(inWav, int(inputLength), outWav, int(outputLength));
@@ -82,7 +113,7 @@ int main(int argc, char* argv[]) {
 
 	// OK, go for it
 	inWav.offset = seekLength;
-	if (processChunkSize <= 0) {
+	if (true || processChunkSize <= 0) {
 		stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
 	} else {
 		signalsmith::plot::Plot2D timePlot(500, 200);
@@ -92,7 +123,7 @@ int main(int argc, char* argv[]) {
 		timePlot.y.minor(0.02*processChunkSize/inWav.sampleRate, "2%");
 		auto &timeLine = timePlot.line();
 		auto &timeLineSeek = timePlot.line().fillToY(0);
-		timeLine.add(inWav.offset, 0); // output seek
+		timeLine.add(outWav.offset, 0); // output seek
 		timeLineSeek.add(0, 0);
 		timeLineSeek.add(0, seekTime);
 		timeLineSeek.add(inWav.offset, seekTime);
@@ -108,14 +139,14 @@ int main(int argc, char* argv[]) {
 			stopwatch.startLap();
 			stretch.process(inWav, toProcess, outWav, outputSamples);
 			double time = stopwatch.seconds(stopwatch.lap());
-			timeLine.add(inWav.offset, time);
-			timeLine.add(inWav.offset + toProcess, time);
+			timeLine.add(outWav.offset, time);
+			timeLine.add(outWav.offset + toProcess, time);
 			
 			inWav.offset += toProcess;
 			outWav.offset += outputSamples;
 		}
 		
-		timeLine.add(inWav.offset, 0);
+		timeLine.add(outWav.offset, 0);
 		timePlot.write(outputWav + ".svg");
 	}
 	

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -7,6 +7,9 @@ using SignalsmithStretch = signalsmith::stretch::SignalsmithStretch<float>;
 
 #include "./util/simple-args.h"
 #include "./util/wav.h"
+#include "./util/stopwatch.h"
+
+#include "plot/plot.h"
 
 int main(int argc, char* argv[]) {
 	SimpleArgs args(argc, argv);
@@ -27,6 +30,7 @@ int main(int argc, char* argv[]) {
 	double tonality = args.flag<double>("tonality", "tonality limit (Hz)", 8000);
 	double asymmetry = args.flag<double>("asymmetry", "asymmetrical STFT analysis (0-1)", 0);
 	bool splitComputation = args.hasFlag("split-computation", "distributes the computation more evenly (but higher latency)");
+	int processChunkSize = args.flag<int>("process-chunk", "process chunk size in samples", -1);
 	args.errorExit(); // exits on error, or with `--help`
 
 	std::cout << inputWav << " -> " << outputWav << "\n";
@@ -57,7 +61,9 @@ int main(int argc, char* argv[]) {
 	// First, an "output seek", where we provide a chunk of input.
 	// This is suitable for starting playback of a sample at a given playback rate.
 	auto seekLength = stretch.outputSeekLength(1/time);
+	signalsmith::Stopwatch stopwatch;
 	stretch.outputSeek(inWav, seekLength);
+	double seekTime = stopwatch.seconds(stopwatch.lap());
 	// At this point, the next output samples we get will correspond to the beginning of the audio file.
 
 	// We're going to process until *just* before the end of the audio file (so we can get a tidier end using `.flush()`.
@@ -76,7 +82,42 @@ int main(int argc, char* argv[]) {
 
 	// OK, go for it
 	inWav.offset = seekLength;
-	stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
+	if (processChunkSize <= 0) {
+		stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
+	} else {
+		signalsmith::plot::Plot2D timePlot(500, 200);
+		timePlot.x.major(0);
+		timePlot.y.major(0);
+		timePlot.y.minor(0.01*processChunkSize/inWav.sampleRate, "1%");
+		timePlot.y.minor(0.02*processChunkSize/inWav.sampleRate, "2%");
+		auto &timeLine = timePlot.line();
+		auto &timeLineSeek = timePlot.line().fillToY(0);
+		timeLine.add(inWav.offset, 0); // output seek
+		timeLineSeek.add(0, 0);
+		timeLineSeek.add(0, seekTime);
+		timeLineSeek.add(inWav.offset, seekTime);
+		timeLineSeek.add(inWav.offset, 0);
+	
+		float residue = 0.f;
+		while (inWav.offset < size_t(inputIndex)) {
+			int toProcess = std::min<int>(processChunkSize, inputIndex - inWav.offset);
+			float outputPrecise = toProcess * time + residue;
+			int outputSamples = std::round(outputPrecise);
+			residue = outputPrecise - outputSamples;
+
+			stopwatch.startLap();
+			stretch.process(inWav, toProcess, outWav, outputSamples);
+			double time = stopwatch.seconds(stopwatch.lap());
+			timeLine.add(inWav.offset, time);
+			timeLine.add(inWav.offset + toProcess, time);
+			
+			inWav.offset += toProcess;
+			outWav.offset += outputSamples;
+		}
+		
+		timeLine.add(inWav.offset, 0);
+		timePlot.write(outputWav + ".svg");
+	}
 	
 	// And as promised, get the last bits using `.flush()`, which does some extra stuff to avoid introducing clicks.
 	outWav.offset = outputIndex;

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -63,21 +63,23 @@ int main(int argc, char* argv[]) {
 		outputPlot.x.major(0);
 		outputPlot.y.major(0);
 
-		stretch.debugAnalysis = [&](int inputOffset, const float *window, bool isPrevious){
+		stretch.debugAnalysis = [&](int inputOffset, const float *window, size_t windowOffset, bool isPrevious){
 			if (plotBlockCounter > 10) return;
 			int blockSamples = stretch.blockSamples();
 			auto &line = inputPlot.line(plotBlockCounter);
 			for (int i = 0; i < blockSamples; ++i) {
 				line.add(inputOffset - blockSamples + i + int(inWav.offset), window[i]);
 			}
+			line.marker(inputOffset - blockSamples + int(windowOffset) + int(inWav.offset), window[windowOffset]);
 		};
-		stretch.debugSynthesis = [&](int outputOffset, const float *window){
+		stretch.debugSynthesis = [&](int outputOffset, const float *window, size_t windowOffset){
 			if (plotBlockCounter > 10) return;
 			int blockSamples = stretch.blockSamples();
 			auto &line = outputPlot.line(plotBlockCounter);
 			for (int i = 0; i < blockSamples; ++i) {
 				line.add(outputOffset + i + int(outWav.offset), window[i]);
 			}
+			line.marker(outputOffset + windowOffset + int(outWav.offset), window[windowOffset]);
 
 			++plotBlockCounter;
 		};
@@ -113,7 +115,7 @@ int main(int argc, char* argv[]) {
 
 	// OK, go for it
 	inWav.offset = seekLength;
-	if (true || processChunkSize <= 0) {
+	if (processChunkSize <= 0) {
 		stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
 	} else {
 		signalsmith::plot::Plot2D timePlot(500, 200);

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -52,14 +52,14 @@ int main(int argc, char* argv[]) {
 	stretch.setFormantSemitones(formants, formantComp);
 	stretch.setFormantBase(formantBase/inWav.sampleRate);
 
-	signalsmith::plot::Figure figure;
-	auto writeLater = figure.writeLater(outputWav + "-blocks.svg");
+	bool plotBlocks = true;
+	signalsmith::plot::Figure blocksFigure;
 	size_t plotBlockCounter = 0;
-	{
-		auto &inputPlot = figure(0, 0).plot(800, 150);
+	if (plotBlocks) {
+		auto &inputPlot = blocksFigure(0, 0).plot(800, 150);
 		inputPlot.x.major(0);
 		inputPlot.y.major(0);
-		auto &outputPlot = figure(0, 1).plot(800, 150);
+		auto &outputPlot = blocksFigure(0, 1).plot(800, 150);
 		outputPlot.x.major(0);
 		outputPlot.y.major(0);
 
@@ -156,6 +156,8 @@ int main(int argc, char* argv[]) {
 	outWav.offset = outputIndex;
 	stretch.flush(outWav, outputLength - outputIndex);
 	outWav.offset = 0;
+
+	if (plotBlocks) blocksFigure.write(outputWav + "-blocks.svg");
 
 	if (!outWav.write(outputWav).warn()) args.errorExit("failed to write WAV");
 }

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -52,39 +52,6 @@ int main(int argc, char* argv[]) {
 	stretch.setFormantSemitones(formants, formantComp);
 	stretch.setFormantBase(formantBase/inWav.sampleRate);
 
-	bool plotBlocks = true;
-	signalsmith::plot::Figure blocksFigure;
-	size_t plotBlockCounter = 0;
-	if (plotBlocks) {
-		auto &inputPlot = blocksFigure(0, 0).plot(800, 150);
-		inputPlot.x.major(0);
-		inputPlot.y.major(0);
-		auto &outputPlot = blocksFigure(0, 1).plot(800, 150);
-		outputPlot.x.major(0);
-		outputPlot.y.major(0);
-
-		stretch.debugAnalysis = [&](int inputOffset, const float *window, size_t windowOffset, bool isPrevious){
-			if (plotBlockCounter > 10) return;
-			int blockSamples = stretch.blockSamples();
-			auto &line = inputPlot.line(plotBlockCounter);
-			for (int i = 0; i < blockSamples; ++i) {
-				line.add(inputOffset - blockSamples + i + int(inWav.offset), window[i]);
-			}
-			line.marker(inputOffset - blockSamples + int(windowOffset) + int(inWav.offset), window[windowOffset]);
-		};
-		stretch.debugSynthesis = [&](int outputOffset, const float *window, size_t windowOffset){
-			if (plotBlockCounter > 10) return;
-			int blockSamples = stretch.blockSamples();
-			auto &line = outputPlot.line(plotBlockCounter);
-			for (int i = 0; i < blockSamples; ++i) {
-				line.add(outputOffset + i + int(outWav.offset), window[i]);
-			}
-			line.marker(outputOffset + int(windowOffset) + int(outWav.offset), window[windowOffset]);
-
-			++plotBlockCounter;
-		};
-	}
-
 	/* Since the WAV helper allows sample access like `wav[c][index]`, we could just call:
 	
 		stretch.exact(inWav, int(inputLength), outWav, int(outputLength));
@@ -118,6 +85,7 @@ int main(int argc, char* argv[]) {
 	if (processChunkSize <= 0) {
 		stretch.process(inWav, inputIndex - seekLength, outWav, outputIndex);
 	} else {
+		// Plot computation time for each chunk
 		signalsmith::plot::Plot2D timePlot(500, 200);
 		timePlot.x.major(0);
 		timePlot.y.major(0);
@@ -156,8 +124,6 @@ int main(int argc, char* argv[]) {
 	outWav.offset = outputIndex;
 	stretch.flush(outWav, outputLength - outputIndex);
 	outWav.offset = 0;
-
-	if (plotBlocks) blocksFigure.write(outputWav + "-blocks.svg");
 
 	if (!outWav.write(outputWav).warn()) args.errorExit("failed to write WAV");
 }

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
 			for (int i = 0; i < blockSamples; ++i) {
 				line.add(outputOffset + i + int(outWav.offset), window[i]);
 			}
-			line.marker(outputOffset + windowOffset + int(outWav.offset), window[windowOffset]);
+			line.marker(outputOffset + int(windowOffset) + int(outWav.offset), window[windowOffset]);
 
 			++plotBlockCounter;
 		};
@@ -142,7 +142,7 @@ int main(int argc, char* argv[]) {
 			stretch.process(inWav, toProcess, outWav, outputSamples);
 			double time = stopwatch.seconds(stopwatch.lap());
 			timeLine.add(outWav.offset, time);
-			timeLine.add(outWav.offset + toProcess, time);
+			timeLine.add(outWav.offset + outputSamples, time);
 			
 			inWav.offset += toProcess;
 			outWav.offset += outputSamples;

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -68,11 +68,12 @@ struct SignalsmithStretch {
 	}
 
 	// Manual setup
-	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false) {
+	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false, Sample asymmetry=0) {
 		_splitComputation = splitComputation;
 		channels = nChannels;
+		asymmetry *= 1 - 2.0*intervalSamples/blockSamples; // maximum asymmetry gives latency of two intervals
 		stft.configure(channels, channels, blockSamples, intervalSamples + 1);
-		stft.setInterval(intervalSamples, stft.kaiser);
+		stft.setInterval(intervalSamples, stft.kaiser, asymmetry);
 		stft.reset(0.1);
 		stashedInput = stft.input;
 		stashedOutput = stft.output;

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -182,40 +182,46 @@ struct SignalsmithStretch {
 	// Moves the input position *and* pre-calculates some output, so that the next samples returned from `.process()` are aligned to the beginning of the sample.
 	// The time-stretch rate is inferred from `inputLength`, so use `.outputSeekLength()` to get a correct value for that.
 	template<class Inputs>
-	void outputSeek(Inputs &&inputs, int inputLength, Sample firstBlockAsymmetry=0.75) {
-		if (firstBlockAsymmetry >= 0) {
-			restoreConfig.pending = true;
-			restoreConfig.interval = stft.defaultInterval();
-			
-			size_t windowOffset = stft.blockSamples()*(1 - firstBlockAsymmetry)/2;
-			size_t windowEnd = stft.synthesisOffset() + stft.defaultInterval();
-			stft.analysisOffset(windowOffset);
-			stft.synthesisOffset(windowOffset);
+	void outputSeek(Inputs &&inputs, int inputLength, Sample firstBlockAsymmetry=0.5) {
+		restoreConfig.pending = true;
+		restoreConfig.interval = stft.defaultInterval();
 
-			// Sine window, warped as two linear segments
-			for (size_t i = 0; i < stft.blockSamples(); ++i) {
-				Sample r = i + Sample(0.5);
-				if (i < windowOffset) {
-					r = r/stft.blockSamples();
-				} else {
-					r = (r - windowOffset)/(windowEnd - windowOffset);
-				}
-				stft.analysisWindow()[i] = stft.synthesisWindow()[i] = (1 - std::cos(r*Sample(2*M_PI)))/2;
+		Sample playbackRate = std::max<int>(inputLength - inputLatency(), 0)/Sample(outputLatency());
+		
+		// Place the next (restored-window) block some time in the future
+		Sample nextBlockOutputStart = stft.defaultInterval()*firstBlockAsymmetry;
+		Sample nextBlockOutputPos = nextBlockOutputStart + stft.synthesisOffset();
+		// The initial block starts some time before time 0
+		Sample firstBlockOutputStart = nextBlockOutputStart - stft.defaultInterval();
+		// Set the initial block's window so it's centred on 0
+		// Use that as the input latency
+		size_t windowOffset = -firstBlockOutputStart;
+		size_t windowEnd = int(nextBlockOutputPos); // first block ends at centre of next block
+		stft.analysisOffset(windowOffset);
+		stft.synthesisOffset(windowOffset);
+
+		// Sine window, warped as two linear segments
+		for (size_t i = 0; i < stft.blockSamples(); ++i) {
+			Sample r = i + Sample(0.5);
+			if (i < windowOffset) {
+				r = r/windowOffset/2;
+			} else if (r < windowEnd) {
+				r = (1 + (r - windowOffset)/(windowEnd - windowOffset))/2;
+			} else {
+				r = 1;
 			}
+			stft.analysisWindow()[i] = stft.synthesisWindow()[i] = (1 - std::cos(r*Sample(2*M_PI)))/2;
 		}
 
 		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
-		stft.reset(0.1);
-		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
-		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
-		Sample playbackRate = surplusInput/Sample(outputLatency());
+		stft.reset(0.01);
+		clearPreviousBlock();
 
-		if (playbackRate > 1) clearPreviousBlock();
-
+		auto seekSamples = inputLatency();
 		// Move the input position to the start of the sound
-		int seekSamples = inputLength - surplusInput;
 		seek(inputs, seekSamples, playbackRate);
-		
+
+		// Enough output to reach the start of the sound
 		auto preRollLength = int(outputLatency());
 		tmpPreRollBuffer.resize(preRollLength*channels);
 		struct BufferOutput {
@@ -229,8 +235,9 @@ struct SignalsmithStretch {
 
 		// Use the surplus input to produce pre-roll output
 		OffsetIO<Inputs> offsetInput{inputs, seekSamples};
-		process(offsetInput, surplusInput, preRollOutput, preRollOutput.length);
-		
+		int preRollInputSamples = std::max<int>(inputLength - seekSamples, 0);
+		process(offsetInput, preRollInputSamples, preRollOutput, preRollLength);
+
 		// put the thing down, flip it and reverse it
 		for (auto &v : tmpPreRollBuffer) v = -v;
 		for (int c = 0; c < channels; ++c) {

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -51,7 +51,7 @@ struct SignalsmithStretch {
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
 
-		if (restoreConfig.pending()) {
+		if (restoreConfig.pending) {
 			stft.setInterval(restoreConfig.interval, stft.kaiser, restoreConfig.asymmetry);
 			restoreConfig = {};
 		}
@@ -572,7 +572,7 @@ struct SignalsmithStretch {
 		// Ordinary process calls, as far as the input goes
 		process(offsetInput, inputMainBlock, outputs, outputMainBlock);
 		
-		OffsetIO<Outputs> offsetOutput{outputs, outputIndex};
+		OffsetIO<Outputs> offsetOutput{outputs, outputMainBlock};
 		// We've run out of input - this gets the last chunk of output (cheaply)
 		flush(offsetOutput, outputSamples - outputMainBlock, playbackRate);
 		return true;

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -564,6 +564,14 @@ private:
 	bool didSeek = false;
 	Sample seekTimeFactor = 1;
 
+	bool assumePreviousBlockZero = false;
+	void clearPreviousBlock() {
+		assumePreviousBlockZero = true;
+		for (auto &b : channelBands) {
+			b.output = b.prevInput = 0;
+		}
+	}
+
 	Sample bandToFreq(Sample b) const {
 		return stft.binToFreq(b);
 	}
@@ -579,14 +587,6 @@ private:
 	std::vector<Band> channelBands;
 	Band * bandsForChannel(int channel) {
 		return channelBands.data() + channel*bands;
-	}
-
-	bool assumePreviousBlockZero = false;
-	void clearPreviousBlock() {
-		assumePreviousBlockZero = true;
-		for (auto &b : channelBands) {
-			b.output = b.prevInput = 0;
-		}
 	}
 
 	template<Complex Band::*member>
@@ -686,7 +686,7 @@ private:
 
 		if (blockProcess.newSpectrum) {
 			if (step < size_t(channels)) {
-//if (assumePreviousBlockZero) return;
+				if (assumePreviousBlockZero) return; // TODO: remove this from the processing schedule
 				int channel = int(step);
 				auto bins = bandsForChannel(channel);
 
@@ -741,7 +741,7 @@ private:
 		}
 		// Preliminary output prediction from phase-vocoder
 		if (step < size_t(channels)) {
-//if (assumePreviousBlockZero) return;
+			if (assumePreviousBlockZero) return; // TODO: remove this from the processing schedule
 			int c = int(step);
 			Band *bins = bandsForChannel(c);
 			auto *predictions = predictionsForChannel(c);

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -40,10 +40,10 @@ struct SignalsmithStretch {
 		
 	// The difference between the internal position (centre of a block) and the input samples you're supplying
 	int inputLatency() const {
-		return int(stft.analysisLatency());
+		return configuredInputLatency;
 	}
 	int outputLatency() const {
-		return int(stft.synthesisLatency() + _splitComputation*stft.defaultInterval());
+		return configuredOutputLatency;
 	}
 	
 	void reset() {
@@ -88,6 +88,8 @@ struct SignalsmithStretch {
 		stft.reset(0.1);
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
+		configuredInputLatency = int(stft.analysisLatency());
+		configuredOutputLatency = int(stft.synthesisLatency() + _splitComputation*stft.defaultInterval());
 
 		bands = int(stft.bands());
 		channelBands.assign(bands*channels, Band());
@@ -186,7 +188,7 @@ struct SignalsmithStretch {
 		restoreConfig.pending = true;
 		restoreConfig.interval = stft.defaultInterval();
 
-		Sample playbackRate = std::max<int>(inputLength - inputLatency(), 0)/Sample(outputLatency());
+		Sample playbackRate = std::max<int>(inputLength - configuredInputLatency, 0)/Sample(configuredOutputLatency);
 		
 		// Place the next (restored-window) block some time in the future
 		Sample nextBlockOutputStart = stft.defaultInterval()*firstBlockAsymmetry;
@@ -217,7 +219,7 @@ struct SignalsmithStretch {
 		stft.reset(0.01);
 		clearPreviousBlock();
 
-		auto seekSamples = inputLatency();
+		auto seekSamples = int(stft.analysisLatency());
 		// Move the input position to the start of the sound
 		seek(inputs, seekSamples, playbackRate);
 
@@ -248,7 +250,7 @@ struct SignalsmithStretch {
 		}
 	}
 	int outputSeekLength(Sample playbackRate) const {
-		return inputLatency() + playbackRate*outputLatency();
+		return configuredInputLatency + playbackRate*configuredOutputLatency;
 	}
 
 	template<class Inputs, class Outputs>
@@ -611,6 +613,7 @@ private:
 	STFT stft;
 	typename STFT::Input stashedInput;
 	typename STFT::Output stashedOutput;
+	int configuredInputLatency = 0, configuredOutputLatency = 0;
 	
 	std::vector<Sample> tmpProcessBuffer, tmpPreRollBuffer;
 	

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -51,10 +51,10 @@ struct SignalsmithStretch {
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
 
-if (restoreInterval) {
-	stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
-	restoreInterval = 0;
-}
+		if (restoreInterval) {
+			stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
+			restoreInterval = 0;
+		}
 		
 		prevInputOffset = -1;
 		assumePreviousBlockZero = true;
@@ -75,6 +75,7 @@ if (restoreInterval) {
 
 Sample configuredAsymmetry = 0;
 int restoreInterval = 0;
+int diffOffsetA = 0, diffOffsetS = 0;
 
 	// Manual setup
 	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false, Sample asymmetry=0) {
@@ -348,8 +349,13 @@ std::function<void(int, const Sample *, size_t)> debugSynthesis;
 
 				updateProcessSpectrumSteps();
 				blockProcess.steps += processSpectrumSteps;
-
+				
 				blockProcess.steps += stft.synthesiseSteps() + 1;
+
+				if (restoreInterval > 0) {
+					blockProcess.resetInterval = true;
+					blockProcess.steps += 1 + channels; // STFT window reset then adjusting prevInput/output
+				}
 			}
 			
 			size_t processToStep = newBlock ? blockProcess.steps : 0;
@@ -436,43 +442,47 @@ if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffs
 					stft.synthesiseStep(step);
 					continue;
 				}
+				step -= stft.synthesiseSteps();
+				
+				if (blockProcess.resetInterval) {
+					if (step-- == 0) {
+						int prevOffsetA = stft.analysisOffset(), prevOffsetS = stft.synthesisOffset();
+						stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
+						restoreInterval = 0;
+
+						diffOffsetA = int(stft.analysisOffset()) - prevOffsetA;
+						diffOffsetS = int(stft.synthesisOffset()) - prevOffsetS;
+						continue;
+					} else if (step < size_t(channels)) {
+						int channel = int(step);
+						auto bins = bandsForChannel(channel);
+						if (diffOffsetA) { // adjust prevInput
+							Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetA*Sample(2*M_PI));
+							Sample freqStep = bandToFreq(1) - bandToFreq(0);
+							Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetA*Sample(2*M_PI));
+							 
+							for (int b = 0; b < bands; ++b) {
+								auto &bin = bins[b];
+								bin.prevInput = _impl::mul(bin.prevInput, rot);
+								rot = _impl::mul(rot, rotStep);
+							}
+						}
+						if (diffOffsetS) {
+							Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetS*Sample(2*M_PI));
+							Sample freqStep = bandToFreq(1) - bandToFreq(0);
+							Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetS*Sample(2*M_PI));
+							 
+							for (int b = 0; b < bands; ++b) {
+								auto &bin = bins[b];
+								bin.output = _impl::mul(bin.output, rot);
+								rot = _impl::mul(rot, rotStep);
+							}
+						}
+						continue;
+					}
+					step -= channels;
+				}
 			}
-if (processToStep == blockProcess.steps && restoreInterval) {
-	int prevOffsetA = stft.analysisOffset(), prevOffsetS = stft.synthesisOffset();
-LOG_EXPR(prevOffsetA);
-LOG_EXPR(prevOffsetS);
-	stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
-	restoreInterval = 0;
-
-	int diffOffsetA = int(stft.analysisOffset()) - prevOffsetA;
-	for (int channel = 0; channel < channels; ++channel) {
-		auto bins = bandsForChannel(channel);
-
-		Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetA*Sample(2*M_PI));
-		Sample freqStep = bandToFreq(1) - bandToFreq(0);
-		Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetA*Sample(2*M_PI));
-		 
-		for (int b = 0; b < bands; ++b) {
-			auto &bin = bins[b];
-			bin.prevInput = _impl::mul(bin.prevInput, rot);
-			rot = _impl::mul(rot, rotStep);
-		}
-	}
-	int diffOffsetS = int(stft.synthesisOffset()) - prevOffsetS;
-	for (int channel = 0; channel < channels; ++channel) {
-		auto bins = bandsForChannel(channel);
-
-		Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetS*Sample(2*M_PI));
-		Sample freqStep = bandToFreq(1) - bandToFreq(0);
-		Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetS*Sample(2*M_PI));
-		 
-		for (int b = 0; b < bands; ++b) {
-			auto &bin = bins[b];
-			bin.output = _impl::mul(bin.output, rot);
-			rot = _impl::mul(rot, rotStep);
-		}
-	}
-}
 #ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP
 			SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP();
 #endif
@@ -571,6 +581,9 @@ private:
 		bool mappedFrequencies = false;
 		bool processFormants = false;
 		Sample timeFactor;
+		
+		// If our previous block had an unusual offset/shape, reset and adjust
+		bool resetInterval = false;
 	} blockProcess;
 
 	using Complex = std::complex<Sample>;

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -50,6 +50,12 @@ struct SignalsmithStretch {
 		stft.reset(0.1);
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
+
+skipPreviousBlock = true;
+if (restoreInterval) {
+	stft.setInterval(stft.defaultInterval(), stft.kaiser, configuredAsymmetry);
+	restoreInterval = false;
+}
 		
 		prevInputOffset = -1;
 		channelBands.assign(channelBands.size(), Band());
@@ -67,12 +73,17 @@ struct SignalsmithStretch {
 		configure(nChannels, sampleRate*0.1, sampleRate*0.04, splitComputation);
 	}
 
+Sample configuredAsymmetry = 0;
+bool restoreInterval = false;
+
 	// Manual setup
 	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false, Sample asymmetry=0) {
 		_splitComputation = splitComputation;
 		channels = nChannels;
 		asymmetry *= 1 - 2.0*intervalSamples/blockSamples; // maximum asymmetry gives latency of two intervals
 		stft.configure(channels, channels, blockSamples, intervalSamples + 1);
+configuredAsymmetry = asymmetry;
+restoreInterval = false;
 		stft.setInterval(intervalSamples, stft.kaiser, asymmetry);
 		stft.reset(0.1);
 		stashedInput = stft.input;
@@ -168,21 +179,41 @@ struct SignalsmithStretch {
 		return int(stft.blockSamples() + stft.defaultInterval());
 	}
 	
+bool skipPreviousBlock = false;
+	
+//int outputSeekInputLatency() const {
+//	return stft.blockSamples()*0.95;
+//}
+
 	// Moves the input position *and* pre-calculates some output, so that the next samples returned from `.process()` are aligned to the beginning of the sample.
 	// The time-stretch rate is inferred from `inputLength`, so use `.outputSeekLength()` to get a correct value for that.
 	template<class Inputs>
 	void outputSeek(Inputs &&inputs, int inputLength) {
+//LOG_EXPR(outputLatency());
+//restoreInterval = true;
+//int newOffset = stft.blockSamples() - outputSeekInputLatency();
+//LOG_EXPR(newOffset);
+//stft.analysisOffset(newOffset);
+//stft.synthesisOffset(newOffset);
+
+skipPreviousBlock = false;
+for (auto &b : channelBands) {
+	b.output = b.prevInput = 0;
+}
+
 		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
-		reset();
+		stft.reset(0.01);
 		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
 		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
+LOG_EXPR(surplusInput);
 		Sample playbackRate = surplusInput/Sample(outputLatency());
 
 		// Move the input position to the start of the sound
 		int seekSamples = inputLength - surplusInput;
 		seek(inputs, seekSamples, playbackRate);
 		
-		tmpPreRollBuffer.resize(outputLatency()*channels);
+		auto preRollLength = int(outputLatency());
+		tmpPreRollBuffer.resize(preRollLength*channels);
 		struct BufferOutput {
 			Sample *samples;
 			int length;
@@ -190,11 +221,14 @@ struct SignalsmithStretch {
 			Sample * operator[](int c) {
 				return samples + c*length;
 			}
-		} preRollOutput{tmpPreRollBuffer.data(), outputLatency()};
-		
+		} preRollOutput{tmpPreRollBuffer.data(), preRollLength};
+
 		// Use the surplus input to produce pre-roll output
 		OffsetIO<Inputs> offsetInput{inputs, seekSamples};
+debugAnalysisOffset = seekSamples;
+debugSynthesisOffset = -preRollLength;
 		process(offsetInput, surplusInput, preRollOutput, preRollOutput.length);
+debugAnalysisOffset = debugSynthesisOffset = 0;
 		
 		// put the thing down, flip it and reverse it
 		for (auto &v : tmpPreRollBuffer) v = -v;
@@ -207,6 +241,10 @@ struct SignalsmithStretch {
 		return inputLatency() + playbackRate*outputLatency();
 	}
 
+int debugAnalysisOffset = 0, debugSynthesisOffset = 0;
+std::function<void(int, const Sample *, bool)> debugAnalysis;
+std::function<void(int, const Sample *)> debugSynthesis;
+
 	template<class Inputs, class Outputs>
 	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
 #ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_START
@@ -214,7 +252,6 @@ struct SignalsmithStretch {
 #endif
 		int prevCopiedInput = 0;
 		auto copyInput = [&](int toIndex){
-
 			int length = std::min<int>(int(stft.blockSamples() + stft.defaultInterval()), toIndex - prevCopiedInput);
 			tmpProcessBuffer.resize(length);
 			int offset = toIndex - length;
@@ -302,6 +339,7 @@ struct SignalsmithStretch {
 				if (blockProcess.newSpectrum) {
 					// make sure the previous input is the correct distance in the past (give or take 1 sample)
 					blockProcess.reanalysePrev = didSeek || std::abs(inputInterval - int(stft.defaultInterval())) > 1;
+					if (skipPreviousBlock) blockProcess.reanalysePrev = false;
 					if (blockProcess.reanalysePrev) blockProcess.steps += stft.analyseSteps() + 1;
 
 					// analyse a new input
@@ -332,6 +370,7 @@ struct SignalsmithStretch {
 #endif
 				if (blockProcess.newSpectrum) {
 					if (blockProcess.reanalysePrev) {
+if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInterval() + debugAnalysisOffset, stft.analysisWindow(), true);
 						// analyse past input
 						if (step < stft.analyseSteps()) {
 							stashedInput.swap(stft.input);
@@ -353,6 +392,8 @@ struct SignalsmithStretch {
 						}
 						step -= 1;
 					}
+
+if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOffset, stft.analysisWindow(), false);
 
 					// Analyse latest (stashed) input
 					if (step < stft.analyseSteps()) {
@@ -396,10 +437,15 @@ struct SignalsmithStretch {
 				step -= 1;
 				
 				if (step < stft.synthesiseSteps()) {
+if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffset, stft.synthesisWindow());
 					stft.synthesiseStep(step);
 					continue;
 				}
 			}
+if (processToStep == blockProcess.steps && restoreInterval) {
+	stft.setInterval(stft.defaultInterval(), stft.kaiser, configuredAsymmetry);
+	restoreInterval = false;
+}
 #ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP
 			SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP();
 #endif
@@ -455,13 +501,17 @@ struct SignalsmithStretch {
 			}
 		}
 		stft.reset(0.1f);
-		// Reset the phase-vocoder stuff, so the next block gets a fresh start
-		for (int c = 0; c < channels; ++c) {
-			auto channelBands = bandsForChannel(c);
-			for (int b = 0; b < bands; ++b) {
-				channelBands[b].prevInput = channelBands[b].output = 0;
-			}
-		}
+skipPreviousBlock = true;
+for (auto &b : channelBands) {
+	b.prevInput = b.output = 0;
+}
+//		// Reset the phase-vocoder stuff, so the next block gets a fresh start
+//		for (int c = 0; c < channels; ++c) {
+//			auto channelBands = bandsForChannel(c);
+//			for (int b = 0; b < bands; ++b) {
+//				channelBands[b].prevInput = channelBands[b].output = 0;
+//			}
+//		}
 	}
 
 	// Process a complete audio buffer all in one go
@@ -642,6 +692,7 @@ private:
 
 		if (blockProcess.newSpectrum) {
 			if (step < size_t(channels)) {
+if (skipPreviousBlock) return;
 				int channel = int(step);
 				auto bins = bandsForChannel(channel);
 
@@ -696,6 +747,7 @@ private:
 		}
 		// Preliminary output prediction from phase-vocoder
 		if (step < size_t(channels)) {
+if (skipPreviousBlock) return;
 			int c = int(step);
 			Band *bins = bandsForChannel(c);
 			auto *predictions = predictionsForChannel(c);
@@ -754,6 +806,7 @@ private:
 					auto &downBin = bins[b - 1];
 					phase += _impl::mul(downBin.output, shortVerticalTwist);
 					
+if (!skipPreviousBlock) {
 					if (b >= longVerticalStep) {
 						Complex longDownInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - longVerticalStep*binTimeFactor);
 						Complex longVerticalTwist = _impl::mul<true>(prediction.input, longDownInput);
@@ -761,8 +814,10 @@ private:
 						auto &longDownBin = bins[b - longVerticalStep];
 						phase += _impl::mul(longDownBin.output, longVerticalTwist);
 					}
+}
 				}
 				// Downwards vertical steps
+if (!skipPreviousBlock) {
 				if (b < bands - 1) {
 					auto &upPrediction = predictions[b + 1];
 					auto &upMapPoint = outputMap[b + 1];
@@ -785,6 +840,7 @@ private:
 						phase += _impl::mul<true>(longUpBin.output, longVerticalTwist);
 					}
 				}
+}
 
 				outputBin.output = prediction.makeOutput(phase);
 				
@@ -802,6 +858,7 @@ private:
 			}
 			return;
 		}
+skipPreviousBlock = false;
 		step -= splitMainPrediction;
 
 		if (blockProcess.newSpectrum) {

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -51,9 +51,9 @@ struct SignalsmithStretch {
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
 
-		if (restoreInterval) {
-			stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
-			restoreInterval = 0;
+		if (restoreConfig.pending()) {
+			stft.setInterval(restoreConfig.interval, stft.kaiser, restoreConfig.asymmetry);
+			restoreConfig = {};
 		}
 		
 		prevInputOffset = -1;
@@ -73,18 +73,17 @@ struct SignalsmithStretch {
 		configure(nChannels, sampleRate*0.1, sampleRate*0.04, splitComputation);
 	}
 
-Sample configuredAsymmetry = 0;
-int restoreInterval = 0;
-int diffOffsetA = 0, diffOffsetS = 0;
-
 	// Manual setup
 	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false, Sample asymmetry=0) {
 		_splitComputation = splitComputation;
 		channels = nChannels;
 		asymmetry *= 1 - 2.0*intervalSamples/blockSamples; // maximum asymmetry gives latency of two intervals
 		stft.configure(channels, channels, blockSamples, intervalSamples + 1);
-configuredAsymmetry = asymmetry;
-restoreInterval = false;
+
+		restoreConfig = {};
+		restoreConfig.interval = intervalSamples;
+		restoreConfig.asymmetry = asymmetry;
+
 		stft.setInterval(intervalSamples, stft.kaiser, asymmetry);
 		stft.reset(0.1);
 		stashedInput = stft.input;
@@ -185,24 +184,23 @@ restoreInterval = false;
 	template<class Inputs>
 	void outputSeek(Inputs &&inputs, int inputLength, Sample firstBlockAsymmetry=0.75) {
 		if (firstBlockAsymmetry >= 0) {
-			restoreInterval = stft.defaultInterval();
-			// Warped sine window
+			restoreConfig.pending = true;
+			restoreConfig.interval = stft.defaultInterval();
 			
 			size_t windowOffset = stft.blockSamples()*(1 - firstBlockAsymmetry)/2;
+			size_t windowEnd = stft.synthesisOffset() + stft.defaultInterval();
 			stft.analysisOffset(windowOffset);
 			stft.synthesisOffset(windowOffset);
 
+			// Sine window, warped as two linear segments
 			for (size_t i = 0; i < stft.blockSamples(); ++i) {
-				Sample r = (i + Sample(0.5))/stft.blockSamples();
-				// Warp as two linear segments
-				if (r < (1 - firstBlockAsymmetry)/2) {
-					r /= (1 - firstBlockAsymmetry);
+				Sample r = i + Sample(0.5);
+				if (i < windowOffset) {
+					r = r/stft.blockSamples();
 				} else {
-					r = 1 + (r - 1)/(firstBlockAsymmetry + 1);
+					r = (r - windowOffset)/(windowEnd - windowOffset);
 				}
-				auto w = (1 - std::cos(r*Sample(2*M_PI)))/2;
-				stft.analysisWindow()[i] = w;
-				stft.synthesisWindow()[i] = w;
+				stft.analysisWindow()[i] = stft.synthesisWindow()[i] = (1 - std::cos(r*Sample(2*M_PI)))/2;
 			}
 		}
 
@@ -231,10 +229,7 @@ restoreInterval = false;
 
 		// Use the surplus input to produce pre-roll output
 		OffsetIO<Inputs> offsetInput{inputs, seekSamples};
-debugAnalysisOffset = seekSamples;
-debugSynthesisOffset = -preRollLength;
 		process(offsetInput, surplusInput, preRollOutput, preRollOutput.length);
-debugAnalysisOffset = debugSynthesisOffset = 0;
 		
 		// put the thing down, flip it and reverse it
 		for (auto &v : tmpPreRollBuffer) v = -v;
@@ -248,10 +243,6 @@ debugAnalysisOffset = debugSynthesisOffset = 0;
 	int outputSeekLength(Sample playbackRate) const {
 		return inputLatency() + playbackRate*outputLatency();
 	}
-
-int debugAnalysisOffset = 0, debugSynthesisOffset = 0;
-std::function<void(int, const Sample *, size_t, bool)> debugAnalysis;
-std::function<void(int, const Sample *, size_t)> debugSynthesis;
 
 	template<class Inputs, class Outputs>
 	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
@@ -364,7 +355,7 @@ std::function<void(int, const Sample *, size_t)> debugSynthesis;
 				
 				blockProcess.steps += stft.synthesiseSteps() + 1;
 
-				if (restoreInterval > 0) {
+				if (restoreConfig.pending > 0) {
 					blockProcess.resetInterval = true;
 					blockProcess.steps += 1 + channels; // STFT window reset then adjusting prevInput/output
 				}
@@ -383,7 +374,6 @@ std::function<void(int, const Sample *, size_t)> debugSynthesis;
 #endif
 				if (blockProcess.newSpectrum) {
 					if (blockProcess.reanalysePrev) {
-if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInterval() + debugAnalysisOffset, stft.analysisWindow(), stft.analysisOffset(), true);
 						// analyse past input
 						if (step < stft.analyseSteps()) {
 							stashedInput.swap(stft.input);
@@ -405,8 +395,6 @@ if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInte
 						}
 						step -= 1;
 					}
-
-if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOffset, stft.analysisWindow(), stft.analysisOffset(), false);
 
 					// Analyse latest (stashed) input
 					if (step < stft.analyseSteps()) {
@@ -450,7 +438,6 @@ if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOff
 				step -= 1;
 				
 				if (step < stft.synthesiseSteps()) {
-if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffset, stft.synthesisWindow(), stft.synthesisOffset());
 					stft.synthesiseStep(step);
 					continue;
 				}
@@ -459,19 +446,19 @@ if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffs
 				if (blockProcess.resetInterval) {
 					if (step-- == 0) {
 						int prevOffsetA = stft.analysisOffset(), prevOffsetS = stft.synthesisOffset();
-						stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
-						restoreInterval = 0;
-
-						diffOffsetA = int(stft.analysisOffset()) - prevOffsetA;
-						diffOffsetS = int(stft.synthesisOffset()) - prevOffsetS;
+						stft.setInterval(restoreConfig.interval, stft.kaiser, restoreConfig.asymmetry);
+						restoreConfig.pending = false;
+						
+						restoreConfig.diffOffsetA = int(stft.analysisOffset()) - prevOffsetA;
+						restoreConfig.diffOffsetS = int(stft.synthesisOffset()) - prevOffsetS;
 						continue;
 					} else if (step < size_t(channels)) {
 						int channel = int(step);
 						auto bins = bandsForChannel(channel);
-						if (diffOffsetA) { // adjust prevInput
-							Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetA*Sample(2*M_PI));
+						if (restoreConfig.diffOffsetA) { // adjust prevInput
+							Complex rot = std::polar(Sample(1), bandToFreq(0)*restoreConfig.diffOffsetA*Sample(2*M_PI));
 							Sample freqStep = bandToFreq(1) - bandToFreq(0);
-							Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetA*Sample(2*M_PI));
+							Complex rotStep = std::polar(Sample(1), freqStep*restoreConfig.diffOffsetA*Sample(2*M_PI));
 							 
 							for (int b = 0; b < bands; ++b) {
 								auto &bin = bins[b];
@@ -479,10 +466,10 @@ if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffs
 								rot = _impl::mul(rot, rotStep);
 							}
 						}
-						if (diffOffsetS) {
-							Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetS*Sample(2*M_PI));
+						if (restoreConfig.diffOffsetS) { // adjust output
+							Complex rot = std::polar(Sample(1), bandToFreq(0)*restoreConfig.diffOffsetS*Sample(2*M_PI));
 							Sample freqStep = bandToFreq(1) - bandToFreq(0);
-							Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetS*Sample(2*M_PI));
+							Complex rotStep = std::polar(Sample(1), freqStep*restoreConfig.diffOffsetS*Sample(2*M_PI));
 							 
 							for (int b = 0; b < bands; ++b) {
 								auto &bin = bins[b];
@@ -616,6 +603,13 @@ private:
 	typename STFT::Output stashedOutput;
 	
 	std::vector<Sample> tmpProcessBuffer, tmpPreRollBuffer;
+	
+	struct {
+		bool pending = false;
+		Sample asymmetry = 0;
+		int interval = 0;
+		int diffOffsetA = 0, diffOffsetS = 0;
+	} restoreConfig;
 
 	int channels = 0, bands = 0;
 	int prevInputOffset = -1;

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -51,13 +51,13 @@ struct SignalsmithStretch {
 		stashedInput = stft.input;
 		stashedOutput = stft.output;
 
-skipPreviousBlock = true;
 if (restoreInterval) {
 	stft.setInterval(stft.defaultInterval(), stft.kaiser, configuredAsymmetry);
 	restoreInterval = false;
 }
 		
 		prevInputOffset = -1;
+		assumePreviousBlockZero = true;
 		channelBands.assign(channelBands.size(), Band());
 		silenceCounter = 0;
 		didSeek = false;
@@ -179,8 +179,6 @@ restoreInterval = false;
 		return int(stft.blockSamples() + stft.defaultInterval());
 	}
 	
-bool skipPreviousBlock = false;
-	
 //int outputSeekInputLatency() const {
 //	return stft.blockSamples()*0.95;
 //}
@@ -196,16 +194,12 @@ bool skipPreviousBlock = false;
 //stft.analysisOffset(newOffset);
 //stft.synthesisOffset(newOffset);
 
-skipPreviousBlock = false;
-for (auto &b : channelBands) {
-	b.output = b.prevInput = 0;
-}
+		clearPreviousBlock();
 
 		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
 		stft.reset(0.01);
 		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
 		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
-LOG_EXPR(surplusInput);
 		Sample playbackRate = surplusInput/Sample(outputLatency());
 
 		// Move the input position to the start of the sound
@@ -242,8 +236,8 @@ debugAnalysisOffset = debugSynthesisOffset = 0;
 	}
 
 int debugAnalysisOffset = 0, debugSynthesisOffset = 0;
-std::function<void(int, const Sample *, bool)> debugAnalysis;
-std::function<void(int, const Sample *)> debugSynthesis;
+std::function<void(int, const Sample *, size_t, bool)> debugAnalysis;
+std::function<void(int, const Sample *, size_t)> debugSynthesis;
 
 	template<class Inputs, class Outputs>
 	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
@@ -339,7 +333,7 @@ std::function<void(int, const Sample *)> debugSynthesis;
 				if (blockProcess.newSpectrum) {
 					// make sure the previous input is the correct distance in the past (give or take 1 sample)
 					blockProcess.reanalysePrev = didSeek || std::abs(inputInterval - int(stft.defaultInterval())) > 1;
-					if (skipPreviousBlock) blockProcess.reanalysePrev = false;
+					if (assumePreviousBlockZero) blockProcess.reanalysePrev = false;
 					if (blockProcess.reanalysePrev) blockProcess.steps += stft.analyseSteps() + 1;
 
 					// analyse a new input
@@ -370,7 +364,7 @@ std::function<void(int, const Sample *)> debugSynthesis;
 #endif
 				if (blockProcess.newSpectrum) {
 					if (blockProcess.reanalysePrev) {
-if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInterval() + debugAnalysisOffset, stft.analysisWindow(), true);
+if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInterval() + debugAnalysisOffset, stft.analysisWindow(), stft.analysisOffset(), true);
 						// analyse past input
 						if (step < stft.analyseSteps()) {
 							stashedInput.swap(stft.input);
@@ -393,7 +387,7 @@ if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset - stft.defaultInte
 						step -= 1;
 					}
 
-if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOffset, stft.analysisWindow(), false);
+if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOffset, stft.analysisWindow(), stft.analysisOffset(), false);
 
 					// Analyse latest (stashed) input
 					if (step < stft.analyseSteps()) {
@@ -437,7 +431,7 @@ if (step == 0 && debugAnalysis) debugAnalysis(prevInputOffset + debugAnalysisOff
 				step -= 1;
 				
 				if (step < stft.synthesiseSteps()) {
-if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffset, stft.synthesisWindow());
+if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffset, stft.synthesisWindow(), stft.synthesisOffset());
 					stft.synthesiseStep(step);
 					continue;
 				}
@@ -501,17 +495,8 @@ if (processToStep == blockProcess.steps && restoreInterval) {
 			}
 		}
 		stft.reset(0.1f);
-skipPreviousBlock = true;
-for (auto &b : channelBands) {
-	b.prevInput = b.output = 0;
-}
-//		// Reset the phase-vocoder stuff, so the next block gets a fresh start
-//		for (int c = 0; c < channels; ++c) {
-//			auto channelBands = bandsForChannel(c);
-//			for (int b = 0; b < bands; ++b) {
-//				channelBands[b].prevInput = channelBands[b].output = 0;
-//			}
-//		}
+
+		clearPreviousBlock();
 	}
 
 	// Process a complete audio buffer all in one go
@@ -595,6 +580,15 @@ private:
 	Band * bandsForChannel(int channel) {
 		return channelBands.data() + channel*bands;
 	}
+
+	bool assumePreviousBlockZero = false;
+	void clearPreviousBlock() {
+		assumePreviousBlockZero = true;
+		for (auto &b : channelBands) {
+			b.output = b.prevInput = 0;
+		}
+	}
+
 	template<Complex Band::*member>
 	Complex getBand(int channel, int index) {
 		if (index < 0 || index >= bands) return 0;
@@ -692,7 +686,7 @@ private:
 
 		if (blockProcess.newSpectrum) {
 			if (step < size_t(channels)) {
-if (skipPreviousBlock) return;
+//if (assumePreviousBlockZero) return;
 				int channel = int(step);
 				auto bins = bandsForChannel(channel);
 
@@ -747,7 +741,7 @@ if (skipPreviousBlock) return;
 		}
 		// Preliminary output prediction from phase-vocoder
 		if (step < size_t(channels)) {
-if (skipPreviousBlock) return;
+//if (assumePreviousBlockZero) return;
 			int c = int(step);
 			Band *bins = bandsForChannel(c);
 			auto *predictions = predictionsForChannel(c);
@@ -806,7 +800,6 @@ if (skipPreviousBlock) return;
 					auto &downBin = bins[b - 1];
 					phase += _impl::mul(downBin.output, shortVerticalTwist);
 					
-if (!skipPreviousBlock) {
 					if (b >= longVerticalStep) {
 						Complex longDownInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - longVerticalStep*binTimeFactor);
 						Complex longVerticalTwist = _impl::mul<true>(prediction.input, longDownInput);
@@ -814,10 +807,8 @@ if (!skipPreviousBlock) {
 						auto &longDownBin = bins[b - longVerticalStep];
 						phase += _impl::mul(longDownBin.output, longVerticalTwist);
 					}
-}
 				}
 				// Downwards vertical steps
-if (!skipPreviousBlock) {
 				if (b < bands - 1) {
 					auto &upPrediction = predictions[b + 1];
 					auto &upMapPoint = outputMap[b + 1];
@@ -840,7 +831,6 @@ if (!skipPreviousBlock) {
 						phase += _impl::mul<true>(longUpBin.output, longVerticalTwist);
 					}
 				}
-}
 
 				outputBin.output = prediction.makeOutput(phase);
 				
@@ -858,7 +848,6 @@ if (!skipPreviousBlock) {
 			}
 			return;
 		}
-skipPreviousBlock = false;
 		step -= splitMainPrediction;
 
 		if (blockProcess.newSpectrum) {
@@ -867,6 +856,7 @@ skipPreviousBlock = false;
 					bin.prevInput = bin.input;
 				}
 			}
+			assumePreviousBlockZero = false;
 		}
 	}
 	

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -180,24 +180,34 @@ restoreInterval = false;
 		return int(stft.blockSamples() + stft.defaultInterval());
 	}
 	
-//int outputSeekInputLatency() const {
-//	return stft.blockSamples()*0.95;
-//}
-
 	// Moves the input position *and* pre-calculates some output, so that the next samples returned from `.process()` are aligned to the beginning of the sample.
 	// The time-stretch rate is inferred from `inputLength`, so use `.outputSeekLength()` to get a correct value for that.
 	template<class Inputs>
-	void outputSeek(Inputs &&inputs, int inputLength) {
-//LOG_EXPR(outputLatency());
-restoreInterval = stft.defaultInterval();
-//stft.setInterval(stft.blockSamples()/2);
-int newOffset = stft.defaultInterval() - 1;
-//LOG_EXPR(newOffset);
-stft.analysisOffset(newOffset);
-stft.synthesisOffset(newOffset);
+	void outputSeek(Inputs &&inputs, int inputLength, Sample firstBlockAsymmetry=0.75) {
+		if (firstBlockAsymmetry >= 0) {
+			restoreInterval = stft.defaultInterval();
+			// Warped sine window
+			
+			size_t windowOffset = stft.blockSamples()*(1 - firstBlockAsymmetry)/2;
+			stft.analysisOffset(windowOffset);
+			stft.synthesisOffset(windowOffset);
+
+			for (size_t i = 0; i < stft.blockSamples(); ++i) {
+				Sample r = (i + Sample(0.5))/stft.blockSamples();
+				// Warp as two linear segments
+				if (r < (1 - firstBlockAsymmetry)/2) {
+					r /= (1 - firstBlockAsymmetry);
+				} else {
+					r = 1 + (r - 1)/(firstBlockAsymmetry + 1);
+				}
+				auto w = (1 - std::cos(r*Sample(2*M_PI)))/2;
+				stft.analysisWindow()[i] = w;
+				stft.synthesisWindow()[i] = w;
+			}
+		}
 
 		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
-		stft.reset(0.01);
+		stft.reset(0.1);
 		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
 		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
 		Sample playbackRate = surplusInput/Sample(outputLatency());
@@ -229,8 +239,10 @@ debugAnalysisOffset = debugSynthesisOffset = 0;
 		// put the thing down, flip it and reverse it
 		for (auto &v : tmpPreRollBuffer) v = -v;
 		for (int c = 0; c < channels; ++c) {
-			std::reverse(preRollOutput[c], preRollOutput[c] + preRollOutput.length);
-			stft.addOutput(c, preRollOutput.length, preRollOutput[c]);
+			std::reverse(preRollOutput[c], preRollOutput[c] + preRollLength);
+			if (_splitComputation) stashedOutput.swap(stft.output);
+			stft.addOutput(c, preRollLength, preRollOutput[c]);
+			if (_splitComputation) stashedOutput.swap(stft.output);
 		}
 	}
 	int outputSeekLength(Sample playbackRate) const {
@@ -787,7 +799,6 @@ private:
 		}
 		// Preliminary output prediction from phase-vocoder
 		if (step < size_t(channels)) {
-			if (assumePreviousBlockZero) return; // TODO: remove this from the processing schedule
 			int c = int(step);
 			Band *bins = bandsForChannel(c);
 			auto *predictions = predictionsForChannel(c);

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -52,8 +52,8 @@ struct SignalsmithStretch {
 		stashedOutput = stft.output;
 
 if (restoreInterval) {
-	stft.setInterval(stft.defaultInterval(), stft.kaiser, configuredAsymmetry);
-	restoreInterval = false;
+	stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
+	restoreInterval = 0;
 }
 		
 		prevInputOffset = -1;
@@ -74,7 +74,7 @@ if (restoreInterval) {
 	}
 
 Sample configuredAsymmetry = 0;
-bool restoreInterval = false;
+int restoreInterval = 0;
 
 	// Manual setup
 	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false, Sample asymmetry=0) {
@@ -188,19 +188,20 @@ restoreInterval = false;
 	template<class Inputs>
 	void outputSeek(Inputs &&inputs, int inputLength) {
 //LOG_EXPR(outputLatency());
-//restoreInterval = true;
-//int newOffset = stft.blockSamples() - outputSeekInputLatency();
+restoreInterval = stft.defaultInterval();
+//stft.setInterval(stft.blockSamples()/2);
+int newOffset = stft.defaultInterval() - 1;
 //LOG_EXPR(newOffset);
-//stft.analysisOffset(newOffset);
-//stft.synthesisOffset(newOffset);
-
-		clearPreviousBlock();
+stft.analysisOffset(newOffset);
+stft.synthesisOffset(newOffset);
 
 		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
 		stft.reset(0.01);
 		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
 		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
 		Sample playbackRate = surplusInput/Sample(outputLatency());
+
+		if (playbackRate > 1) clearPreviousBlock();
 
 		// Move the input position to the start of the sound
 		int seekSamples = inputLength - surplusInput;
@@ -437,8 +438,40 @@ if (step == 0 && debugSynthesis) debugSynthesis(outputIndex + debugSynthesisOffs
 				}
 			}
 if (processToStep == blockProcess.steps && restoreInterval) {
-	stft.setInterval(stft.defaultInterval(), stft.kaiser, configuredAsymmetry);
-	restoreInterval = false;
+	int prevOffsetA = stft.analysisOffset(), prevOffsetS = stft.synthesisOffset();
+LOG_EXPR(prevOffsetA);
+LOG_EXPR(prevOffsetS);
+	stft.setInterval(restoreInterval, stft.kaiser, configuredAsymmetry);
+	restoreInterval = 0;
+
+	int diffOffsetA = int(stft.analysisOffset()) - prevOffsetA;
+	for (int channel = 0; channel < channels; ++channel) {
+		auto bins = bandsForChannel(channel);
+
+		Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetA*Sample(2*M_PI));
+		Sample freqStep = bandToFreq(1) - bandToFreq(0);
+		Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetA*Sample(2*M_PI));
+		 
+		for (int b = 0; b < bands; ++b) {
+			auto &bin = bins[b];
+			bin.prevInput = _impl::mul(bin.prevInput, rot);
+			rot = _impl::mul(rot, rotStep);
+		}
+	}
+	int diffOffsetS = int(stft.synthesisOffset()) - prevOffsetS;
+	for (int channel = 0; channel < channels; ++channel) {
+		auto bins = bandsForChannel(channel);
+
+		Complex rot = std::polar(Sample(1), bandToFreq(0)*diffOffsetS*Sample(2*M_PI));
+		Sample freqStep = bandToFreq(1) - bandToFreq(0);
+		Complex rotStep = std::polar(Sample(1), freqStep*diffOffsetS*Sample(2*M_PI));
+		 
+		for (int b = 0; b < bands; ++b) {
+			auto &bin = bins[b];
+			bin.output = _impl::mul(bin.output, rot);
+			rot = _impl::mul(rot, rotStep);
+		}
+	}
 }
 #ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP
 			SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP();

--- a/signalsmith-stretch.h
+++ b/signalsmith-stretch.h
@@ -566,12 +566,15 @@ struct SignalsmithStretch {
 
 		outputSeek(inputs, seekLength);
 
-		int outputIndex = outputSamples - seekLength/playbackRate;
 		OffsetIO<Inputs> offsetInput{inputs, seekLength};
-		process(offsetInput, inputSamples - seekLength, outputs, outputIndex);
+		int inputMainBlock = inputSamples - seekLength;
+		int outputMainBlock = inputMainBlock/playbackRate;
+		// Ordinary process calls, as far as the input goes
+		process(offsetInput, inputMainBlock, outputs, outputMainBlock);
 		
 		OffsetIO<Outputs> offsetOutput{outputs, outputIndex};
-		flush(offsetOutput, outputSamples - outputIndex, playbackRate);
+		// We've run out of input - this gets the last chunk of output (cheaply)
+		flush(offsetOutput, outputSamples - outputMainBlock, playbackRate);
 		return true;
 	}
 


### PR DESCRIPTION
When starting sample playback, the `.outputSeek()` method computes a bunch of output up-front, so that the first call to `.process()` produces output for the beginning of the sample.

Previously, this was done by `.seek()`ing into the input, producing `.outputLatency()` samples using normal processing.  The pre-roll output is "reflected back" (reversed and phase-inverted before adding back in, to avoid the click you'd get from truncation).

Here's a diagram of the analysis (top) and synthesis (bottom) windows for the first 10 output blocks, including those computed during`.outputSeek()`:

![dev-100 wav-blocks](https://github.com/user-attachments/assets/67fd72a3-bac8-4e90-acb6-7f22ff261323)

The input for `t < 0` is effectively zeroes, and the output for `t < 0` is reflected back.  This is with 4x overlap, so there are two output windows which need to be computed up-front before the "actual" output is ready.  There are also two analysis windows for each output block, because this is performing a time-stretch.

## Improvement 1: skip one analysis

The first change in this branch/PR is the internal flag `assumePreviousBlockZero`.  This is actually true after a `.reset()`, but we _pretend_ it's true directly after `.outputSeek()`.  This means we avoid one input-block analysis when time-stretching:

![dev-100 wav-blocks](https://github.com/user-attachments/assets/3cb793d2-ebcf-421d-aaee-e42fd12b29e8)

### Affect on the sound

The first output block has no "previous input" to use for a phase-vocoder prediction.  This isn't a problem, since that phase-vocoder prediction is only really needed to remain phase-aligned to a previous block.

If anything, I would expect this first block to actually be _clearer_ on initial transients, but that needs to be backed up by thorough listening tests.

## Improvement 2: different initial window shape

This change changes the window shape (and block centre) at the start of `.outputSeek()`.  The previous window shapes are then restored for the next block:

![dev-100 wav-blocks](https://github.com/user-attachments/assets/4a16cacc-fd57-4ada-a6a0-3aec8c18f24c)

Since the input is padded with zeros, and the output gets folded back, this first block's window doesn't need to extend very far before `t=0`.  However, since the analysis/synthesis "window offsets" (marked with a dot in these diagrams) are the reference time for the analysis/synthesis, we also perform an additional phase-shift to adjust for this changing when we restore the original window shapes/offsets.

## Limits to the performance improvement

If `splitComputation` is turned off, then Stretch periodically does a big chunk of work as it computes the next output block.  In an environment with large buffer sizes (or enough buffering to handle the uneven CPU use), this isn't a problem - here's the computation time if we compute chunks of 2048 samples at a time:

![dev-2048-sc wav](https://github.com/user-attachments/assets/d2a4dc0b-cf04-4330-83a1-e0828b292842)

However, for 512 samples we can see that most blocks barely do any work:

![dev-512 wav](https://github.com/user-attachments/assets/93e54f2a-c084-4b85-ad2b-337020f2cfcc)

### Split-computation

Split-computation mode spreads this work out more evenly (without any threading stuff), at the expense of some extra output latency:

![dev-512-sc wav](https://github.com/user-attachments/assets/cabb869d-1a89-4590-aa21-a202666573ee)

This difference is even more dramatic for smaller buffer sizes.  Here's the difference if we use 100-sample buffers:

![dev-100 wav](https://github.com/user-attachments/assets/27b11358-531b-4e70-b3f1-01c57e3248e6)
![dev-100-sc wav](https://github.com/user-attachments/assets/d4e6b98f-a1b1-449e-ab30-71df0a191403)

**However!**  On all of these plots I've added the time of the `.outputSeek()` call, scaled to CPU% as if it's a single 512/2048/... buffer.  (The width shows the amount of pre-roll it actually has to compute.)  Since this is up-front work to get the Stretch instance ready to produce actual output, split-computation doesn't help.

## Future alternatives

I think I've taken this particular approach as far as it can reasonably go.

The only option I can see for getting the CPU cost of `.outputSeek()` all the way down (to match the `smoothedComputation` case) is to use a much cheaper method to generate that initial output.  We would then need to re-analyse that output so we can phase-match it from the next typical Stretch processing-block.

The most general approach would be to allow the user to generate some initial output themselves, and then tell Stretch to continue based on that output.